### PR TITLE
4.8.1

### DIFF
--- a/lib/domain/sight.dart
+++ b/lib/domain/sight.dart
@@ -6,11 +6,12 @@ class Sight {
   final String details;
   final String type;
 
-  const Sight(
-      {required this.name,
-      required this.lat,
-      required this.lon,
-      required this.url,
-      required this.details,
-      required this.type,});
+  const Sight({
+    required this.name,
+    required this.lat,
+    required this.lon,
+    required this.url,
+    required this.details,
+    required this.type,
+  });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,9 +18,7 @@ class App extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: SightDetailsScreen(
-        sight: mocks[0],
-      ),
+      home: const SightListScreen(),
     );
   }
 }

--- a/lib/mocs.dart
+++ b/lib/mocs.dart
@@ -27,12 +27,12 @@ final List<Sight> mocks = [
     type: 'sports construction',
   ),
   const Sight(
-      name: 'Niagara Falls',
-      lat: 43.0799,
-      lon: 79.0747,
-      url:
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/3Falls_Niagara.jpg/1920px-3Falls_Niagara.jpg',
-      details: '''
+    name: 'Niagara Falls',
+    lat: 43.0799,
+    lon: 79.0747,
+    url:
+        'https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/3Falls_Niagara.jpg/1920px-3Falls_Niagara.jpg',
+    details: '''
   Niagara Falls /naɪˈæɡrə, naɪˈæɡərə/ is a group of three waterfalls at the southern end of Niagara Gorge,
   spanning the border between the province of Ontario in Canada and the state of New York in the United States.
   The largest of the three is Horseshoe Falls, also known as Canadian Falls, which straddles the international
@@ -46,5 +46,6 @@ final List<Sight> mocks = [
   Niagara Falls is famed for its beauty and is a valuable source of hydroelectric power.
   Balancing recreational, commercial, and industrial uses has been a challenge for the stewards 
   of the falls since the 19th century.''',
-      type: 'natural wonder'),
+    type: 'natural wonder',
+  ),
 ];

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -12,75 +12,83 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: [
-          Container(
-            height: 96,
-            decoration: const BoxDecoration(
-              borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-              color: Colors.amber,
-            ),
-            child: Stack(
-              children: [
-                Positioned(
-                  left: 16,
-                  top: 16,
-                  child: Text(
-                    sight.type,
-                    style: const TextStyle(
+    return AspectRatio(
+      aspectRatio: 3 / 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Container(
+              height: 96,
+              decoration: const BoxDecoration(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+                color: Colors.amber,
+              ),
+              child: Stack(
+                children: [
+                  Positioned(
+                    left: 16,
+                    top: 16,
+                    child: Text(
+                      sight.type,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontFamily: 'Roboto',
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 16,
+                    right: 16,
+                    child: Container(
+                      width: 20,
+                      height: 18,
                       color: Colors.white,
-                      fontFamily: 'Roboto',
-                      fontWeight: FontWeight.bold,
-                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            Container(
+              height: 92,
+              decoration: const BoxDecoration(
+                color: Color.fromRGBO(245, 245, 245, 1),
+              ),
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: RichText(
+                    text: TextSpan(
+                      style: const TextStyle(
+                        fontFamily: 'Roboto',
+                        color: Color.fromRGBO(59, 62, 91, 1),
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      text: '${sight.name}\n',
+                      children: const [
+                        TextSpan(
+                          text: 'краткое описание',
+                          style: TextStyle(
+                            color: Color.fromRGBO(124, 126, 146, 1),
+                            fontSize: 14,
+                            fontWeight: FontWeight.normal,
+                          ),
+                        )
+                      ],
                     ),
                   ),
                 ),
-                Positioned(
-                  top: 16,
-                  right: 16,
-                  child: Container(
-                    width: 20,
-                    height: 18,
-                    color: Colors.white,
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Container(
-            height: 92,
-            decoration: const BoxDecoration(
-              color: Color.fromRGBO(245, 245, 245, 1),
-            ),
-            child: Align(
-              alignment: Alignment.topLeft,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: RichText(
-                    text: TextSpan(
-                        style: const TextStyle(
-                          fontFamily: 'Roboto',
-                          color: Color.fromRGBO(59, 62, 91, 1),
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        ),
-                        text: '${sight.name}\n',
-                        children: const [
-                      TextSpan(
-                        text: 'краткое описание',
-                        style: TextStyle(
-                          color: Color.fromRGBO(124, 126, 146, 1),
-                          fontSize: 14,
-                          fontWeight: FontWeight.normal,
-                        ),
-                      )
-                    ])),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -50,35 +50,36 @@ class SightCard extends StatelessWidget {
             ),
           ),
           Container(
-              height: 92,
-              decoration: const BoxDecoration(
-                color: Color.fromRGBO(245, 245, 245, 1),
+            height: 92,
+            decoration: const BoxDecoration(
+              color: Color.fromRGBO(245, 245, 245, 1),
+            ),
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: RichText(
+                    text: TextSpan(
+                        style: const TextStyle(
+                          fontFamily: 'Roboto',
+                          color: Color.fromRGBO(59, 62, 91, 1),
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                        text: '${sight.name}\n',
+                        children: const [
+                      TextSpan(
+                        text: 'краткое описание',
+                        style: TextStyle(
+                          color: Color.fromRGBO(124, 126, 146, 1),
+                          fontSize: 14,
+                          fontWeight: FontWeight.normal,
+                        ),
+                      )
+                    ])),
               ),
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: RichText(
-                      text: TextSpan(
-                          style: const TextStyle(
-                            fontFamily: 'Roboto',
-                            color: Color.fromRGBO(59, 62, 91, 1),
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
-                          ),
-                          text: '${sight.name}\n',
-                          children: const [
-                        TextSpan(
-                          text: 'краткое описание',
-                          style: TextStyle(
-                            color: Color.fromRGBO(124, 126, 146, 1),
-                            fontSize: 14,
-                            fontWeight: FontWeight.normal,
-                          ),
-                        )
-                      ])),
-                ),
-              )),
+            ),
+          ),
         ],
       ),
     );

--- a/lib/ui/screen/sight_details_screen.dart
+++ b/lib/ui/screen/sight_details_screen.dart
@@ -23,7 +23,9 @@ class SightDetailsScreen extends StatelessWidget {
                 width: 32,
                 decoration: const BoxDecoration(
                     color: _defaultBackgroundColor,
-                    borderRadius: BorderRadius.all(Radius.circular(10))),
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(10),
+                    )),
               ),
             ),
           ],

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -3,44 +3,40 @@ import 'package:places/mocs.dart';
 import 'package:places/ui/screen/sight_card.dart';
 
 const Color _defaultAppBarTextColor = Color.fromRGBO(37, 40, 73, 1);
-const double _appBarHeight = 72;
-const double _appBarTopPadding = 64;
-const double _appBarElevation = 0;
-Padding _appBarTitleText = Padding(
-  padding: const EdgeInsets.only(top: _appBarTopPadding),
-  child: RichText(
-    text: const TextSpan(
-      style: TextStyle(
-        fontFamily: 'Roboto',
-        fontWeight: FontWeight.w700,
-        fontSize: 32,
-      ),
-      children: [
-        TextSpan(
-          text: 'С',
-          style: TextStyle(
-            color: Color.fromRGBO(76, 175, 80, 1),
-          ),
-          children: [
-            TextSpan(
-              text: 'писок\n',
-              style: TextStyle(color: _defaultAppBarTextColor),
-            ),
-          ],
-        ),
-        TextSpan(
-            text: 'и',
-            style: TextStyle(
-              color: Color.fromRGBO(251, 192, 45, 1),
-            ),
-            children: [
-              TextSpan(
-                text: 'нтересных мест',
-                style: TextStyle(color: _defaultAppBarTextColor),
-              )
-            ]),
-      ],
+
+RichText _appBarTitleText = RichText(
+  text: const TextSpan(
+    style: TextStyle(
+      fontFamily: 'Roboto',
+      fontWeight: FontWeight.w700,
+      fontSize: 32,
     ),
+    children: [
+      TextSpan(
+        text: 'С',
+        style: TextStyle(
+          color: Color.fromRGBO(76, 175, 80, 1),
+        ),
+        children: [
+          TextSpan(
+            text: 'писок\n',
+            style: TextStyle(color: _defaultAppBarTextColor),
+          ),
+        ],
+      ),
+      TextSpan(
+        text: 'и',
+        style: TextStyle(
+          color: Color.fromRGBO(251, 192, 45, 1),
+        ),
+        children: [
+          TextSpan(
+            text: 'нтересных мест',
+            style: TextStyle(color: _defaultAppBarTextColor),
+          ),
+        ],
+      ),
+    ],
   ),
 );
 
@@ -55,12 +51,11 @@ class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: _appBarHeight + _appBarTopPadding,
-        elevation: _appBarElevation,
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        title: _appBarTitleText,
-      ),
+      appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(150),
+          child: CustomAppBar(
+            title: _appBarTitleText,
+          )),
       body: SingleChildScrollView(
         padding: const EdgeInsets.only(top: 16),
         child: Column(
@@ -72,5 +67,22 @@ class _SightListScreenState extends State<SightListScreen> {
         ),
       ),
     );
+  }
+}
+
+class CustomAppBar extends StatelessWidget {
+  final Widget title;
+  final double elevation;
+
+  const CustomAppBar({
+    required this.title,
+    this.elevation = 0,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        padding: const EdgeInsets.fromLTRB(16, 64, 16, 0), child: title);
   }
 }

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -17,16 +17,17 @@ Padding _appBarTitleText = Padding(
       ),
       children: [
         TextSpan(
-            text: 'С',
-            style: TextStyle(
-              color: Color.fromRGBO(76, 175, 80, 1),
+          text: 'С',
+          style: TextStyle(
+            color: Color.fromRGBO(76, 175, 80, 1),
+          ),
+          children: [
+            TextSpan(
+              text: 'писок\n',
+              style: TextStyle(color: _defaultAppBarTextColor),
             ),
-            children: [
-              TextSpan(
-                text: 'писок\n',
-                style: TextStyle(color: _defaultAppBarTextColor),
-              ),
-            ],),
+          ],
+        ),
         TextSpan(
             text: 'и',
             style: TextStyle(


### PR DESCRIPTION
// В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся? // 
Если размеры текста по ширине преодолевали середину, то текст переносился на следующую строку в связи с тем, что от родителя приходит единственное ограничение, это не занимать размер больше самого родителя, но за счёт ConstrainedBox мы расширяем ограничения по ширине и запрещаем ему быть больше половины родителя.